### PR TITLE
update hha api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,10 +1581,29 @@ name = "hc_utils"
 version = "0.3.1"
 source = "git+https://github.com/holochain/hc-utils?branch=v0.0.110#1726915536c372ed8a6fbc711890fe6098de6b19"
 dependencies = [
- "hdk",
- "holo_hash",
+ "hdk 0.0.110",
+ "holo_hash 0.0.9",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "hdk"
+version = "0.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df307ee1ddbc819b292761091270837f090c52627e46cb9555c7c40a42e9363"
+dependencies = [
+ "hdk_derive 0.0.9",
+ "holo_hash 0.0.7",
+ "holochain_wasmer_guest",
+ "holochain_zome_types 0.0.9",
+ "paste",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1593,10 +1612,10 @@ version = "0.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f3aaf323a4ea33bc3ca6b2746806e8c0a78f8327422127db4b1ad62367a8d63"
 dependencies = [
- "hdk_derive",
- "holo_hash",
+ "hdk_derive 0.0.12",
+ "holo_hash 0.0.9",
  "holochain_wasmer_guest",
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "paste",
  "serde",
  "serde_bytes",
@@ -1608,11 +1627,24 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247b98b122ff7bf6703d2b1877c4211082c602a1265d0d9e79db351446ef1cdc"
+dependencies = [
+ "holochain_zome_types 0.0.9",
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "hdk_derive"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17a1f910b2473c62c71eab0574fd81f1aff46cf23708bad8276b8156872ca67"
 dependencies = [
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "paste",
  "proc-macro2",
  "quote",
@@ -1650,6 +1682,7 @@ dependencies = [
  "holochain",
  "holochain_types",
  "holochain_websocket",
+ "holofuel_types",
  "isahc",
  "observability",
  "reqwest",
@@ -1665,6 +1698,18 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "url 2.2.2",
+]
+
+[[package]]
+name = "holo_hash"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70ba98cfdd900d746c37163d088225f16031c283e71017d6671e40b9503c429"
+dependencies = [
+ "holochain_serialized_bytes",
+ "serde",
+ "serde_bytes",
+ "thiserror",
 ]
 
 [[package]]
@@ -1708,7 +1753,7 @@ dependencies = [
  "fixt",
  "futures",
  "ghost_actor 0.3.0-alpha.4",
- "holo_hash",
+ "holo_hash 0.0.9",
  "holochain_cascade",
  "holochain_conductor_api",
  "holochain_keystore",
@@ -1721,7 +1766,7 @@ dependencies = [
  "holochain_wasm_test_utils",
  "holochain_wasmer_host",
  "holochain_websocket",
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "human-panic",
  "kitsune_p2p",
  "kitsune_p2p_types",
@@ -1776,15 +1821,15 @@ dependencies = [
  "fixt",
  "futures",
  "ghost_actor 0.3.0-alpha.4",
- "hdk",
- "hdk_derive",
- "holo_hash",
+ "hdk 0.0.110",
+ "hdk_derive 0.0.12",
+ "holo_hash 0.0.9",
  "holochain_p2p",
  "holochain_serialized_bytes",
  "holochain_sqlite",
  "holochain_state",
  "holochain_types",
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "kitsune_p2p",
  "mockall",
  "observability",
@@ -1804,12 +1849,12 @@ checksum = "26277ec64a2b0c6bf3bf167c9670484f68c43a815810fe6eb4bfaf2a5c8620a9"
 dependencies = [
  "derive_more",
  "directories 2.0.2",
- "holo_hash",
+ "holo_hash 0.0.9",
  "holochain_p2p",
  "holochain_serialized_bytes",
  "holochain_state",
  "holochain_types",
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "kitsune_p2p",
  "serde",
  "serde_derive",
@@ -1827,10 +1872,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dc70467e031d894138e2574f671a525a1e857005c1444e5095586787ebd8eac"
 dependencies = [
  "ghost_actor 0.3.0-alpha.4",
- "holo_hash",
+ "holo_hash 0.0.9",
  "holochain_serialized_bytes",
  "holochain_sqlite",
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "kitsune_p2p_types",
  "lair_keystore_client",
  "nanoid 0.4.0",
@@ -1853,12 +1898,12 @@ dependencies = [
  "fixt",
  "futures",
  "ghost_actor 0.3.0-alpha.4",
- "holo_hash",
+ "holo_hash 0.0.9",
  "holochain_keystore",
  "holochain_serialized_bytes",
  "holochain_types",
  "holochain_util",
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "kitsune_p2p",
  "kitsune_p2p_types",
  "mockall",
@@ -1913,10 +1958,10 @@ dependencies = [
  "fallible-iterator",
  "fixt",
  "futures",
- "holo_hash",
+ "holo_hash 0.0.9",
  "holochain_serialized_bytes",
  "holochain_util",
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "kitsune_p2p",
  "lazy_static",
  "must_future",
@@ -1958,7 +2003,7 @@ dependencies = [
  "derive_more",
  "either",
  "fallible-iterator",
- "holo_hash",
+ "holo_hash 0.0.9",
  "holochain_keystore",
  "holochain_p2p",
  "holochain_serialized_bytes",
@@ -1966,7 +2011,7 @@ dependencies = [
  "holochain_types",
  "holochain_util",
  "holochain_wasm_test_utils",
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "kitsune_p2p",
  "mockall",
  "one_err",
@@ -2002,12 +2047,12 @@ dependencies = [
  "fixt",
  "flate2",
  "futures",
- "holo_hash",
+ "holo_hash 0.0.9",
  "holochain_keystore",
  "holochain_serialized_bytes",
  "holochain_sqlite",
  "holochain_util",
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "itertools 0.10.1",
  "lazy_static",
  "mockall",
@@ -2054,10 +2099,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127ef5b9b11f2d46bf981d1d5fe646b3aa2ac1a0aba7924027f533504f03e9cc"
 dependencies = [
  "fixt",
- "holo_hash",
+ "holo_hash 0.0.9",
  "holochain_types",
  "holochain_util",
- "holochain_zome_types",
+ "holochain_zome_types 0.0.12",
  "rand 0.7.3",
  "strum",
  "strum_macros",
@@ -2134,6 +2179,25 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e51e5c52432490fc6e6a6885f7ec61da4fa0df103419b4297b561ad4dc5c7ec"
+dependencies = [
+ "chrono",
+ "holo_hash 0.0.7",
+ "holochain_serialized_bytes",
+ "holochain_wasmer_common",
+ "kitsune_p2p_timestamp 0.0.3",
+ "paste",
+ "serde",
+ "serde_bytes",
+ "subtle",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "holochain_zome_types"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee607f26a79107bcc6b87f06c3f89f27e88aeea07d2c656e228da8953884f14"
@@ -2143,10 +2207,10 @@ dependencies = [
  "contrafact",
  "derive_builder",
  "fixt",
- "holo_hash",
+ "holo_hash 0.0.9",
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
- "kitsune_p2p_timestamp",
+ "kitsune_p2p_timestamp 0.0.5",
  "nanoid 0.3.0",
  "num_enum",
  "once_cell",
@@ -2161,6 +2225,20 @@ dependencies = [
  "subtle-encoding",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "holofuel_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545d80be5b536a047ae9ed2a1b8fa60742371a5a1537ce90496996612db6f471"
+dependencies = [
+ "chrono",
+ "hdk 0.0.107",
+ "lazy_static",
+ "regex",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -2457,7 +2535,7 @@ dependencies = [
  "itertools 0.10.1",
  "kitsune_p2p_mdns",
  "kitsune_p2p_proxy",
- "kitsune_p2p_timestamp",
+ "kitsune_p2p_timestamp 0.0.5",
  "kitsune_p2p_transport_quic",
  "kitsune_p2p_types",
  "observability",
@@ -2528,6 +2606,17 @@ dependencies = [
  "tokio",
  "tracing-subscriber",
  "webpki",
+]
+
+[[package]]
+name = "kitsune_p2p_timestamp"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507278ec2536a6db8c4c2349ad972add821cc23e84a9afbe039a560e1d3c250b"
+dependencies = [
+ "chrono",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ base64 = "0.13.0"
 hc_utils = {git = "https://github.com/holochain/hc-utils", branch = "v0.0.110", package = "hc_utils"}
 reqwest = { version = "0.11", features = ["json"]}
 spinning_top = "=0.2.0"
+holofuel_types = "0.1.0"
 
 [dependencies.holochain]
 version = "=0.0.110"
@@ -42,5 +43,3 @@ package = "holochain_websocket"
 [dev-dependencies.cargo-husky]
 version = "1"
 features = ["run-cargo-fmt", "run-cargo-clippy"]
-
-

--- a/src/entries.rs
+++ b/src/entries.rs
@@ -1,5 +1,6 @@
 use hc_utils::{WrappedAgentPubKey, WrappedHeaderHash};
 use holochain_types::prelude::MembraneProof;
+use holofuel_types::fuel::Fuel;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -11,19 +12,33 @@ pub struct DnaResource {
     pub nick: String,
 }
 #[derive(Deserialize, Debug, Clone)]
-pub struct HappBundle {
-    pub hosted_url: String,
-    pub bundle_url: String,
-    pub happ_alias: String,
-    pub ui_src_url: String,
-    pub name: String,
-    pub dnas: Vec<DnaResource>,
+pub struct HostingPrices {
+    cpu: Fuel,
+    storage: Fuel,
+    bandwidth: Fuel,
 }
-#[derive(Deserialize, Debug)]
-pub struct HappBundleDetails {
-    pub happ_id: WrappedHeaderHash,
-    pub happ_bundle: HappBundle,
+#[derive(Deserialize, Debug, Clone)]
+pub struct LoginConfig {
+    require_joining_code: bool,
+    display_publisher_name: bool,
+    help_url: Option<String>,
+}
+#[derive(Deserialize, Debug, Clone)]
+pub struct PresentedHappBundle {
+    pub id: WrappedHeaderHash,
     pub provider_pubkey: WrappedAgentPubKey,
+    pub is_draft: bool,
+    pub bundle_url: String,
+    pub ui_src_url: String,
+    pub dnas: Vec<DnaResource>,
+    pub hosted_url: String,
+    pub name: String,
+    pub logo_url: String,
+    pub description: String,
+    pub categories: Vec<String>,
+    pub jurisdictions: Vec<String>,
+    pub hosting_prices: HostingPrices,
+    pub login_config: LoginConfig,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod config;
 pub use config::{Config, Happ, HappsFile, MembraneProofFile, ProofPayload};
 
 mod entries;
-pub use entries::{DnaResource, HappBundle, HappBundleDetails, InstallHappBody, Preferences};
+pub use entries::{DnaResource, InstallHappBody, Preferences, PresentedHappBundle};
 
 mod websocket;
 pub use websocket::{AdminWebsocket, AppWebsocket};
@@ -133,11 +133,11 @@ pub async fn get_all_enabled_hosted_happs(
                 // return Vec of happ_list.happ_id
                 AppResponse::ZomeCall(r) => {
                     info!("ZomeCall Response - Hosted happs List {:?}", r);
-                    let happ_bundles: Vec<HappBundleDetails> =
+                    let happ_bundles: Vec<PresentedHappBundle> =
                         rmp_serde::from_read_ref(r.as_bytes())?;
                     let happ_bundle_ids = happ_bundles
                         .into_iter()
-                        .map(|happ| (happ.happ_id, happ.happ_bundle.dnas))
+                        .map(|happ| (happ.id, happ.dnas))
                         .collect();
                     Ok(happ_bundle_ids)
                 }


### PR DESCRIPTION
Update to HHA API. This change corresponds with [Holo-Hosting-App v0.1.1-alpha4](https://holo-host.github.io/holo-hosting-app-rsm/)

Depends on https://github.com/Holo-Host/holo-auto-installer/pull/8
Should merge that first