### PR TITLE
bump hpos-service-crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "hpos_hc_connect"
 version = "0.1.0"
-source = "git+https://github.com/holo-host/hpos-service-crates.git?rev=1a333b0688dbc7a2dbbe64eb25a2d98f8200b14d#1a333b0688dbc7a2dbbe64eb25a2d98f8200b14d"
+source = "git+https://github.com/holo-host/hpos-service-crates.git?rev=6e44748cea253ab391a3f92b93acf4aca4976366#6e44748cea253ab391a3f92b93acf4aca4976366"
 dependencies = [
  "again",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ mr_bundle = { version = "0.4.0-dev.4" }
 hpos-config-core = { git = "https://github.com/Holo-Host/hpos-config", rev = "a36f862869cc162c843ac27ed617910d68f480cc" }
 hpos-config-seed-bundle-explorer ={ git = "https://github.com/Holo-Host/hpos-config", rev = "a36f862869cc162c843ac27ed617910d68f480cc" }
 chrono = "0.4.33"
-hpos_hc_connect = { git = "https://github.com/holo-host/hpos-service-crates.git", rev = "1a333b0688dbc7a2dbbe64eb25a2d98f8200b14d" }
+hpos_hc_connect = { git = "https://github.com/holo-host/hpos-service-crates.git", rev = "6e44748cea253ab391a3f92b93acf4aca4976366" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use hpos_hc_connect::AdminWebsocket;
 
 use anyhow::Result;
 use holochain_types::dna::{hash_type::Agent, HoloHash};
-use hpos_hc_connect::{hha_agent::HHAAgent, holo_config::Config};
+use hpos_hc_connect::{hha_agent::CoreAppAgent, holo_config::Config};
 use std::collections::HashMap;
 use tracing::{debug, error, info};
 use types::hbs::{HbsClient, KycLevel};
@@ -34,7 +34,7 @@ pub async fn run(config: &Config) -> Result<()> {
     };
     debug!("Got host credentials from hbs {:?}", host_credentials);
 
-    let mut core_app = HHAAgent::spawn(Some(config)).await?;
+    let mut core_app = CoreAppAgent::spawn(Some(config)).await?;
 
     // Suspend happs that have overdue payments
     let pending_transactions = core_app.get_pending_transactions().await?;

--- a/src/types/hbs.rs
+++ b/src/types/hbs.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use anyhow::Result;
 use base64::prelude::*;
 use holochain_types::prelude::{holochain_serial, SerializedBytes, Signature, Timestamp};
-use hpos_hc_connect::hha_agent::HHAAgent;
+use hpos_hc_connect::hha_agent::CoreAppAgent;
 use hpos_hc_connect::hpos_agent::get_hpos_config;
 use reqwest::Response;
 use serde::{Deserialize, Serialize};
@@ -158,7 +158,7 @@ impl HbsClient {
             | hpos_config_core::Config::V2 { settings, .. } => settings.admin.email,
         };
 
-        let mut core_app = HHAAgent::spawn(None).await?;
+        let mut core_app = CoreAppAgent::spawn(None).await?;
         let pub_key = core_app.pubkey().await?;
 
         tracing::debug!("email: {:?}, pub_key: {:?}", email, pub_key);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,7 +12,7 @@ use holochain_types::dna::ActionHashB64;
 use holochain_types::prelude::{AppManifest, MembraneProof, SerializedBytes, UnsafeBytes};
 use holofuel_types::fuel::Fuel;
 use hpos_hc_connect::{
-    hha_agent::HHAAgent,
+    hha_agent::CoreAppAgent,
     holofuel_types::{PendingTransaction, POS},
     utils::download_file,
     AdminWebsocket,
@@ -55,7 +55,7 @@ pub async fn load_mem_proof_file(bundle_url: &str) -> Result<HashMap<String, Mem
 }
 
 pub async fn get_all_published_hosted_happs(
-    core_app_client: &mut HHAAgent,
+    core_app_client: &mut CoreAppAgent,
 ) -> Result<Vec<HappBundle>> {
     trace!("get_all_published_hosted_happs");
 
@@ -228,7 +228,7 @@ pub async fn should_be_enabled(
 
 /// Installs all happs that are eligible for hosting
 pub async fn install_holo_hosted_happs(
-    core_app_client: &mut HHAAgent,
+    core_app_client: &mut CoreAppAgent,
     admin_port: u16,
     happs: &[HappBundle],
     is_kyc_level_2: bool,
@@ -385,7 +385,7 @@ pub async fn install_holo_hosted_happs(
 /// Ineligible Happs = old holo-hosted happs, holo-disabled happs, suspended happs, or happs with one of the following:
 ///  - 1. an invalid pricing for kyc level, 2. invalid pricing preference, 3. invalid uptime, or 4. invalid jurisdiction
 pub async fn handle_ineligible_happs(
-    core_app_client: &mut HHAAgent,
+    core_app_client: &mut CoreAppAgent,
     admin_port: u16,
     suspended_happs: Vec<String>,
     host_credentials: HostCredentials,


### PR DESCRIPTION
Bumps to ref `6e44748cea253ab391a3f92b93acf4aca4976366` in hpos-service-crates, which fixes the app interface spawning issue.

> gitlab ticket: https://gitlab.holo.host/holodev/americas/holo-hosting-project/-/issues/202