### PR TITLE
latest hpos_hc_connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holo-auto-installer"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "again",
  "anyhow",
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "hpos_hc_connect"
 version = "0.1.0"
-source = "git+https://github.com/holo-host/hpos-service-crates.git?rev=83b5bba4839f141a02ce5123ee7c915763f145e7#83b5bba4839f141a02ce5123ee7c915763f145e7"
+source = "git+https://github.com/holo-host/hpos-service-crates.git?rev=81485983b949884e7a574cae519818b628f57865#81485983b949884e7a574cae519818b628f57865"
 dependencies = [
  "again",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holo-auto-installer"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Joel U <joelulahanna@gmail.com>"]
 edition = "2021"
 
@@ -34,4 +34,4 @@ mr_bundle = { version = "0.4.0-dev.4" }
 hpos-config-core = { git = "https://github.com/Holo-Host/hpos-config", rev = "a36f862869cc162c843ac27ed617910d68f480cc" }
 hpos-config-seed-bundle-explorer ={ git = "https://github.com/Holo-Host/hpos-config", rev = "a36f862869cc162c843ac27ed617910d68f480cc" }
 chrono = "0.4.33"
-hpos_hc_connect = { git = "https://github.com/holo-host/hpos-service-crates.git", rev = "83b5bba4839f141a02ce5123ee7c915763f145e7" }
+hpos_hc_connect = { git = "https://github.com/holo-host/hpos-service-crates.git", rev = "81485983b949884e7a574cae519818b628f57865" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use hpos_hc_connect::AdminWebsocket;
 
 use anyhow::Result;
 use holochain_types::dna::{hash_type::Agent, HoloHash};
-use hpos_hc_connect::{hha_agent::HHAAgent, holo_config::Config};
+use hpos_hc_connect::{hha_agent::CoreAppAgent, holo_config::Config};
 use std::collections::HashMap;
 use tracing::{debug, error, info};
 use types::hbs::{HbsClient, KycLevel};
@@ -37,7 +37,7 @@ pub async fn run(config: &Config) -> Result<()> {
     };
     debug!("Got host credentials from hbs {:?}", host_credentials);
 
-    let mut core_app = HHAAgent::spawn(Some(config)).await?;
+    let mut core_app = CoreAppAgent::spawn(Some(config)).await?;
 
     // Suspend happs that have overdue payments
     let pending_transactions = core_app.get_pending_transactions().await?;

--- a/src/types/hbs.rs
+++ b/src/types/hbs.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use anyhow::Result;
 use base64::prelude::*;
 use holochain_types::prelude::{holochain_serial, SerializedBytes, Signature, Timestamp};
-use hpos_hc_connect::hha_agent::HHAAgent;
+use hpos_hc_connect::hha_agent::CoreAppAgent;
 use hpos_hc_connect::hpos_agent::get_hpos_config;
 use reqwest::Response;
 use serde::{Deserialize, Serialize};
@@ -158,7 +158,7 @@ impl HbsClient {
             | hpos_config_core::Config::V2 { settings, .. } => settings.admin.email,
         };
 
-        let mut core_app = HHAAgent::spawn(None).await?;
+        let mut core_app = CoreAppAgent::spawn(None).await?;
         let pub_key = core_app.pubkey().await?;
 
         tracing::debug!("email: {:?}, pub_key: {:?}", email, pub_key);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,7 +11,7 @@ use holochain_types::dna::ActionHashB64;
 use holochain_types::prelude::{AppManifest, MembraneProof, SerializedBytes, UnsafeBytes};
 use holofuel_types::fuel::Fuel;
 use hpos_hc_connect::{
-    hha_agent::HHAAgent,
+    hha_agent::CoreAppAgent,
     holofuel_types::{PendingTransaction, POS},
     utils::download_file,
     AdminWebsocket,
@@ -65,7 +65,7 @@ pub async fn load_mem_proof_file(bundle_url: &str) -> Result<HashMap<String, Mem
 }
 
 pub async fn get_all_published_hosted_happs(
-    core_app_client: &mut HHAAgent,
+    core_app_client: &mut CoreAppAgent,
 ) -> Result<Vec<HappBundle>> {
     trace!("get_all_published_hosted_happs");
 
@@ -239,7 +239,7 @@ pub async fn should_be_enabled(
 
 /// Installs anonymous instance for all happs that are eligible for hosting
 pub async fn install_holo_hosted_happs(
-    core_app_client: &mut HHAAgent,
+    core_app_client: &mut CoreAppAgent,
     admin_port: u16,
     happs: &[HappBundle],
     is_kyc_level_2: bool,
@@ -393,7 +393,7 @@ pub async fn install_holo_hosted_happs(
 /// Ineligible Happs = old holo-hosted happs, holo-disabled happs, suspended happs, or happs with one of the following:
 ///  - 1. an invalid pricing for kyc level, 2. invalid pricing preference, 3. invalid uptime, or 4. invalid jurisdiction
 pub async fn handle_ineligible_happs(
-    core_app_client: &mut HHAAgent,
+    core_app_client: &mut CoreAppAgent,
     admin_port: u16,
     suspended_happs: Vec<String>,
     host_credentials: HostCredentials,


### PR DESCRIPTION
Bumps to ref `81485983b949884e7a574cae519818b628f57865` in hpos-service-crates, which fixes the app interface spawning issue AND includes the sl rotation feature.

> gitlab ticket: https://gitlab.holo.host/holodev/americas/holo-hosting-project/-/issues/202